### PR TITLE
Do not specify io-console versions that conflicts bundles one

### DIFF
--- a/io-nosey.gemspec
+++ b/io-nosey.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = Gem::Requirement.new('>= 3.1')
 
-  gem.add_runtime_dependency 'io-console', '>= 0.5.11', '< 0.7.0'
   gem.add_runtime_dependency 'eqq', '~> 0.1.1'
   gem.add_runtime_dependency 'optionalargument', '~> 0.6.0'
 


### PR DESCRIPTION
irb(main):001:0> require 'io/nosey'
/nix/store/iq92i5f1l6h0pih8r0b31sl43v22a2ib-ruby-3.2.2/lib/ruby/3.2.0/rubygems/specification.rb:2295:in `raise_if_conflicts': Unable to activate io-nosey-0.4.0, because io-console-0.6.0 conflicts with io-console (~> 0.5.11) (Gem::ConflictError)